### PR TITLE
Fixed ::price to assert isNumeric since data is not returned in an array

### DIFF
--- a/IEX.cpp
+++ b/IEX.cpp
@@ -770,7 +770,7 @@ Json::Value IEX::stocks::price(const std::string &symbol)
     std::string url(IEX_ENDPOINT);
     url += "/stock/"+symbol+"/price";
     IEX::sendGetRequest(jsonData, url);
-    assert(jsonData.isArray()); //Crash if not an array
+    assert(jsonData.isNumeric()); //Crash if not numeric
     return jsonData;
 }
 


### PR DESCRIPTION
Hello.   This if my first ever pull request on github, so please correct me if I've done anything wrong. ;)

I tried to use ::price to check a stock and was greeted with an assert.  When using my browser to check the same URL I noticed it was returned as a number, not as an array with a number in it.  This PR changes the assert to verify that it returns a number with `isNumeric()`.